### PR TITLE
Add Hot Chocolate v15 subgraph services

### DIFF
--- a/Accounts/Accounts.csproj
+++ b/Accounts/Accounts.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Accounts/Program.cs
+++ b/Accounts/Program.cs
@@ -1,5 +1,7 @@
 using Accounts;
 using Microsoft.EntityFrameworkCore;
+using HotChocolate.AspNetCore;
+using HotChocolate.Execution.Configuration;
 
 var builder = WebApplication.CreateBuilder(args);
 {
@@ -13,6 +15,13 @@ var builder = WebApplication.CreateBuilder(args);
     builder.Services.AddDbContextFactory<AccountDbContext>(opt => opt
         .UseSqlite("Data Source=app.db")
         .EnableSensitiveDataLogging());
+
+    builder.Services
+        .AddGraphQLServer()
+        .AddQueryType<Query>()
+        .AddFiltering()
+        .AddSorting()
+        .AddProjections();
 }
 
 var app = builder.Build();

--- a/Accounts/Query.cs
+++ b/Accounts/Query.cs
@@ -1,0 +1,26 @@
+using Accounts.Models;
+using Microsoft.EntityFrameworkCore;
+using HotChocolate;
+using HotChocolate.Types;
+using HotChocolate.Data;
+
+namespace Accounts;
+
+public class Query
+{
+    [UsePaging(IncludeTotalCount = true)]
+    [UseProjection]
+    [UseFiltering]
+    [UseSorting]
+    public IQueryable<User> GetUsers(AccountDbContext dbContext)
+        => dbContext.Users;
+
+    public Task<User?> GetUserByIdAsync(int id, AccountDbContext dbContext)
+        => dbContext.Users.FirstOrDefaultAsync(t => t.Id == id);
+
+    public async Task<IEnumerable<User>> GetUsersByIdAsync(int[] ids, AccountDbContext dbContext)
+        => await dbContext.Users.Where(t => ids.Contains(t.Id)).ToListAsync();
+
+    public Task<User?> GetUserByUsernameAsync(string username, AccountDbContext dbContext)
+        => dbContext.Users.FirstOrDefaultAsync(t => t.Username == username);
+}

--- a/GatewayGraphQL/GatewayGraphQL.csproj
+++ b/GatewayGraphQL/GatewayGraphQL.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Reviews/Program.cs
+++ b/Reviews/Program.cs
@@ -1,5 +1,6 @@
 using Microsoft.EntityFrameworkCore;
 using Reviews;
+using HotChocolate.AspNetCore;
 
 var builder = WebApplication.CreateBuilder(args);
 {
@@ -14,6 +15,15 @@ var builder = WebApplication.CreateBuilder(args);
     builder.Services.AddDbContextFactory<ReviewDbContext>(opt =>
         opt.UseSqlite("Data Source=app.db").EnableSensitiveDataLogging()
     );
+
+    builder.Services
+        .AddGraphQLServer()
+        .AddQueryType<Query>()
+        .AddTypeExtension<Reviews.Types.UserResolvers>()
+        .AddTypeExtension<Reviews.Types.ReviewResolvers>()
+        .AddFiltering()
+        .AddSorting()
+        .AddProjections();
 }
 
 var app = builder.Build();

--- a/Reviews/Query.cs
+++ b/Reviews/Query.cs
@@ -1,0 +1,26 @@
+using Microsoft.EntityFrameworkCore;
+using HotChocolate;
+using HotChocolate.Types;
+using HotChocolate.Data;
+using Reviews.Types;
+
+namespace Reviews;
+
+public class Query
+{
+    [UsePaging(IncludeTotalCount = true)]
+    [UseProjection]
+    [UseFiltering]
+    [UseSorting]
+    public IQueryable<Review> GetReviews(ReviewDbContext dbContext)
+        => dbContext.Reviews;
+
+    public Task<Review?> GetReviewByIdAsync(int id, ReviewDbContext dbContext)
+        => dbContext.Reviews.FirstOrDefaultAsync(r => r.Id == id);
+
+    public async Task<IEnumerable<Review>> GetReviewsByIdAsync(int[] ids, ReviewDbContext dbContext)
+        => await dbContext.Reviews.Where(r => ids.Contains(r.Id)).ToListAsync();
+
+    public async Task<IEnumerable<Review>> GetReviewsByUserIdAsync(int[] userIds, ReviewDbContext dbContext)
+        => await dbContext.Reviews.Where(r => userIds.Contains(r.UserId)).ToListAsync();
+}

--- a/Reviews/Reviews.csproj
+++ b/Reviews/Reviews.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>

--- a/Reviews/Types/ReviewResolvers.cs
+++ b/Reviews/Types/ReviewResolvers.cs
@@ -1,0 +1,10 @@
+using HotChocolate;
+using HotChocolate.Types;
+
+namespace Reviews.Types;
+
+[ExtendObjectType(typeof(Review))]
+public class ReviewResolvers
+{
+    public User GetUser([Parent] Review review) => new User { Id = review.UserId };
+}

--- a/Reviews/Types/User.cs
+++ b/Reviews/Types/User.cs
@@ -1,0 +1,6 @@
+namespace Reviews.Types;
+
+public class User
+{
+    public int Id { get; set; }
+}

--- a/Reviews/Types/UserResolvers.cs
+++ b/Reviews/Types/UserResolvers.cs
@@ -1,0 +1,18 @@
+using HotChocolate;
+using HotChocolate.Types;
+using HotChocolate.Data;
+using Reviews.Types;
+using Reviews;
+
+namespace Reviews.Types;
+
+[ExtendObjectType(typeof(User))]
+public class UserResolvers
+{
+    [UsePaging(IncludeTotalCount = true)]
+    [UseProjection]
+    [UseFiltering]
+    [UseSorting]
+    public IQueryable<Review> GetReviews([Parent] User user, ReviewDbContext dbContext)
+        => dbContext.Reviews.Where(r => r.UserId == user.Id);
+}


### PR DESCRIPTION
## Summary
- set up Accounts subgraph with GraphQL server, query endpoints and batching
- implement Reviews subgraph with query endpoints and type extensions for federated relations
- target .NET 8 across services

## Testing
- `dotnet build`
- `curl -s -X POST -H "Content-Type: application/json" --data '{"query":"{ reviews { nodes { id } } }"}' http://localhost:5260/graphql`
- `curl -s -X POST -H "Content-Type: application/json" --data '{"query":"{ users { nodes { id name username } } }"}' http://localhost:5204/graphql`


------
https://chatgpt.com/codex/tasks/task_e_689a265b10248323b19ab96fbca42462