### PR TITLE
Batch user review lookup to avoid duplicate queries

### DIFF
--- a/Reviews/DataLoaders/ReviewsByUserIdDataLoader.cs
+++ b/Reviews/DataLoaders/ReviewsByUserIdDataLoader.cs
@@ -1,0 +1,46 @@
+using GreenDonut;
+using Microsoft.EntityFrameworkCore;
+using Reviews;
+using Reviews.Types;
+using System.Threading;
+
+namespace Reviews.DataLoaders;
+
+public class ReviewsByUserIdDataLoader : BatchDataLoader<int, IReadOnlyList<Review>>
+{
+    private readonly IDbContextFactory<ReviewDbContext> _dbContextFactory;
+
+    public ReviewsByUserIdDataLoader(
+        IBatchScheduler batchScheduler,
+        IDbContextFactory<ReviewDbContext> dbContextFactory,
+        DataLoaderOptions? options = null)
+        : base(batchScheduler, options)
+    {
+        _dbContextFactory = dbContextFactory;
+    }
+
+    protected override async Task<IReadOnlyDictionary<int, IReadOnlyList<Review>>> LoadBatchAsync(
+        IReadOnlyList<int> keys,
+        CancellationToken cancellationToken)
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var reviews = await dbContext.Reviews
+            .Where(r => keys.Contains(r.UserId))
+            .ToListAsync(cancellationToken);
+
+        var grouped = reviews
+            .GroupBy(r => r.UserId)
+            .ToDictionary(g => g.Key, g => (IReadOnlyList<Review>)g.ToList());
+
+        foreach (var key in keys)
+        {
+            if (!grouped.ContainsKey(key))
+            {
+                grouped[key] = Array.Empty<Review>();
+            }
+        }
+
+        return grouped;
+    }
+}

--- a/Reviews/Program.cs
+++ b/Reviews/Program.cs
@@ -23,7 +23,8 @@ var builder = WebApplication.CreateBuilder(args);
         .AddTypeExtension<Reviews.Types.ReviewResolvers>()
         .AddFiltering()
         .AddSorting()
-        .AddProjections();
+        .AddProjections()
+        .AddDataLoader<Reviews.DataLoaders.ReviewsByUserIdDataLoader>();
 }
 
 var app = builder.Build();

--- a/Reviews/Types/UserResolvers.cs
+++ b/Reviews/Types/UserResolvers.cs
@@ -3,6 +3,7 @@ using HotChocolate.Data;
 using HotChocolate.Types;
 using Reviews;
 using Reviews.Types;
+using System.Threading;
 
 namespace Reviews.Types;
 
@@ -12,6 +13,12 @@ public class UserResolvers
     [UseProjection]
     [UseFiltering]
     [UseSorting]
-    public IQueryable<Review> GetReviews([Parent] User user, ReviewDbContext dbContext) =>
-        dbContext.Reviews.Where(r => r.UserId == user.Id);
+    public async Task<IQueryable<Review>> GetReviews(
+        [Parent] User user,
+        DataLoaders.ReviewsByUserIdDataLoader dataLoader,
+        CancellationToken cancellationToken)
+    {
+        var reviews = await dataLoader.LoadAsync(user.Id, cancellationToken);
+        return reviews.AsQueryable();
+    }
 }


### PR DESCRIPTION
## Summary
- batch review fetches by user with `ReviewsByUserIdDataLoader`
- resolve reviews via dataloader to avoid duplicate DB queries
- register review dataloader in Reviews server

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_689a2fd0e3dc8323a202eb38163564e0